### PR TITLE
Fix multiple bugs in reconfiguration, connection stability, entity creation and alarm control

### DIFF
--- a/custom_components/crowipmodule/CHANGES
+++ b/custom_components/crowipmodule/CHANGES
@@ -1,0 +1,33 @@
+v.0.22
+- System binary sensors are converted to alarm control panel device attributes.
+- If 'code' configuration is missing in configuration.yaml, then keypad is on in Alarm Panel.
+- 'code' configuration is moved to 'areas' section for area specific code.
+- Bugfix: Corrected some errors.
+v.0.23
+- Bugfix: Corrected deepcopy dict, which results area_keypad device attributes to be the same as alarm_control_panel.
+- Bugfix: Corrected alarm trigger updates of both area_keypad and alarm_control_panel.
+v.0.24
+- Removed sensor.area_a_keypad and added sensor.crow_alarm_system; this new sensor has all system related attributes only.
+- Bugfix: Handle trigger based disconnection issue.
+- Bugfix: Corrected some issues.
+v.0.25
+- Bugfix: Corrected HA 103 breaking changes made on alarm_control_panel.
+- Bugfix: Outputs controlling and status corrected.
+v.0.26
+- When HA restarts; update all entities just after the connection is established.
+- Check network disconnects real-time.
+- ESA waits until STATUS request
+v.0.27
+- Added RL1 and RL2 Relays
+v.0.28
+- Bugfix: Removed "loop" from pycrowipmodule as per new Python requirements
+v.0.31
+- Bugfix: Convert sleep to asyncio sleep in pycrowipmodule and disarm to async
+- Added SUPPORT_ALARM_TRIGGER for panic alarm (Don't know if it works)
+v.0.32
+- fix HA deprecation warnings
+- updated pycrowipmodule to 0.31b0
+- add code_arm_required to config options
+v.0.33
+- fix HA deprecation warnings
+- update pycrowipmodule to 0.32 which also fixes warnings

--- a/custom_components/crowipmodule/__init__.py
+++ b/custom_components/crowipmodule/__init__.py
@@ -78,7 +78,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             async_dispatcher_send(hass, SIGNAL_AREA_UPDATE, None)
             async_dispatcher_send(hass, SIGNAL_ZONE_UPDATE, None)
             async_dispatcher_send(hass, SIGNAL_OUTPUT_UPDATE, None)
-        hass.loop.create_task(delayed_refresh())
+        # create_task is NOT thread-safe — use run_coroutine_threadsafe to
+        # schedule the coroutine onto HA's event loop from the panel's background thread.
+        asyncio.run_coroutine_threadsafe(delayed_refresh(), hass.loop)
 
     def connection_fail_callback(data):
         _LOGGER.warning("Connection lost/failed to Crow IP Module. Reconnecting...")

--- a/custom_components/crowipmodule/alarm_control_panel.py
+++ b/custom_components/crowipmodule/alarm_control_panel.py
@@ -19,10 +19,12 @@ from .const import (
     SIGNAL_AREA_UPDATE,
     SIGNAL_KEYPAD_UPDATE,
     CONF_AREAS,
+    CONF_NUM_AREAS,
+    DEFAULT_NUM_AREAS,
     CONF_FW_VERSION,
     CONF_FW_DATE,
     DEFAULT_FW_VERSION,
-    DEFAULT_FW_DATE # <--- Dieser Import funktioniert jetzt wieder
+    DEFAULT_FW_DATE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -41,11 +43,13 @@ async def async_setup_entry(
     fw_date = entry.data.get(CONF_FW_DATE, DEFAULT_FW_DATE)
     
     configured_areas = options.get(CONF_AREAS, {})
-    
+
     if not configured_areas:
+        # Fall back to creating bare area entries based on the configured count
+        num_areas = entry.data.get(CONF_NUM_AREAS, DEFAULT_NUM_AREAS)
         configured_areas = {
-            "1": {"name": "Area 1", "code": "", "code_arm_required": True},
-            "2": {"name": "Area 2", "code": "", "code_arm_required": True}
+            str(i): {"name": f"Area {i}", "code": "", "code_arm_required": True}
+            for i in range(1, num_areas + 1)
         }
 
     devices = []
@@ -54,7 +58,8 @@ async def async_setup_entry(
             area_num = int(area_num_str)
             devices.append(CrowAlarmPanel(
                 controller, host,
-                area_num, 
+                entry.entry_id,
+                area_num,
                 area_data.get("name", f"Area {area_num}"),
                 area_data.get("code", ""),
                 area_data.get("code_arm_required", True),
@@ -70,16 +75,18 @@ class CrowAlarmPanel(AlarmControlPanelEntity):
     _attr_has_entity_name = True
     _attr_name = None
 
-    def __init__(self, controller, host, area_number, name, code, code_required, fw_version, fw_date) -> None:
+    def __init__(self, controller, host, entry_id, area_number, name, code, code_required, fw_version, fw_date) -> None:
         self._controller = controller
         self._host = host
         self._fw_string = f"{fw_version} ({fw_date})"
-        
+
         self._area_number_int = area_number
         self._area_number = "A" if area_number == 1 else "B"
-        
+
         self._attr_name = name
-        self._attr_unique_id = f"crow_area_{area_number}"
+        # Include entry_id so unique_id is scoped per config entry and entity_id
+        # is generated from the correct area name on first registration.
+        self._attr_unique_id = f"{entry_id}_crow_area_{area_number}"
         self._attr_icon = "mdi:shield-home"
         
         self._code = code
@@ -115,10 +122,15 @@ class CrowAlarmPanel(AlarmControlPanelEntity):
 
     @property
     def code_format(self) -> CodeFormat | None:
+        # Always return NUMBER so HA knows the input type and renders arm/disarm
+        # buttons correctly. Visibility of the code field is controlled by
+        # code_arm_required below.
         return CodeFormat.NUMBER
 
     @property
     def code_arm_required(self) -> bool:
+        # If a code is pre-stored in config the user never needs to type one;
+        # it is sent internally. Return False so HA makes the field optional.
         if self._code:
             return False
         return self._code_arm_required_config
@@ -142,10 +154,10 @@ class CrowAlarmPanel(AlarmControlPanelEntity):
     async def async_alarm_arm_home(self, code: str | None = None) -> None:
         _LOGGER.info("User requested ARM STAY for Area %s", self._area_number)
         try:
+            # ARM/STAY commands are standalone on the Crow protocol - no code follow-up.
+            # Calling send_keypress here would send a KEYS command (identical to disarm)
+            # and immediately cancel the arm.
             self._controller.arm_stay()
-            code_to_use = str(code) if code else str(self._code)
-            if code_to_use:
-                self._controller.send_keypress(code_to_use)
         except Exception as e:
              _LOGGER.error("Error sending arm home command: %s", e)
 
@@ -153,9 +165,6 @@ class CrowAlarmPanel(AlarmControlPanelEntity):
         _LOGGER.info("User requested ARM AWAY for Area %s", self._area_number)
         try:
             self._controller.arm_away()
-            code_to_use = str(code) if code else str(self._code)
-            if code_to_use:
-                self._controller.send_keypress(code_to_use)
         except Exception as e:
              _LOGGER.error("Error sending arm away command: %s", e)
 

--- a/custom_components/crowipmodule/config_flow.py
+++ b/custom_components/crowipmodule/config_flow.py
@@ -80,7 +80,7 @@ class CrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Required(CONF_FW_VERSION, default=DEFAULT_FW_VERSION): vol.In(fw_options),
             
             vol.Required(CONF_NUM_AREAS, default=DEFAULT_NUM_AREAS): vol.All(vol.Coerce(int), vol.Range(min=1, max=MAX_AREAS)),
-            vol.Required(CONF_NUM_OUTPUTS, default=DEFAULT_NUM_OUTPUTS): vol.All(vol.Coerce(int), vol.Range(min=1, max=MAX_OUTPUTS)),
+            vol.Required(CONF_NUM_OUTPUTS, default=DEFAULT_NUM_OUTPUTS): vol.All(vol.Coerce(int), vol.Range(min=0, max=MAX_OUTPUTS)),
             vol.Required(CONF_NUM_ZONES, default=DEFAULT_NUM_ZONES): vol.All(vol.Coerce(int), vol.Range(min=1, max=MAX_ZONES)),
         })
 
@@ -109,6 +109,11 @@ class CrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_outputs(self, user_input=None):
         count = self._data.get(CONF_NUM_OUTPUTS, DEFAULT_NUM_OUTPUTS)
+
+        if count == 0:
+            self._options[CONF_OUTPUTS] = {}
+            self._zone_page = 0
+            return await self.async_step_zones()
 
         if user_input is not None:
             outputs_config = {}
@@ -204,7 +209,7 @@ class CrowOptionsFlowHandler(config_entries.OptionsFlow):
             vol.Required(CONF_FW_VERSION, default=current_fw): vol.In(fw_options),
 
             vol.Required(CONF_NUM_AREAS, default=c_areas): vol.All(vol.Coerce(int), vol.Range(min=1, max=MAX_AREAS)),
-            vol.Required(CONF_NUM_OUTPUTS, default=c_outputs): vol.All(vol.Coerce(int), vol.Range(min=1, max=MAX_OUTPUTS)),
+            vol.Required(CONF_NUM_OUTPUTS, default=c_outputs): vol.All(vol.Coerce(int), vol.Range(min=0, max=MAX_OUTPUTS)),
             vol.Required(CONF_NUM_ZONES, default=c_zones): vol.All(vol.Coerce(int), vol.Range(min=1, max=MAX_ZONES)),
         })
 
@@ -232,7 +237,13 @@ class CrowOptionsFlowHandler(config_entries.OptionsFlow):
 
     async def async_step_outputs(self, user_input=None):
         count = self._temp_data.get(CONF_NUM_OUTPUTS, DEFAULT_NUM_OUTPUTS)
-        
+
+        if count == 0:
+            self._temp_options[CONF_OUTPUTS] = {}
+            self._zone_page = 0
+            self._temp_options[CONF_ZONES] = {}
+            return await self.async_step_zones()
+
         if user_input is not None:
             self._temp_options[CONF_OUTPUTS] = {}
             for i in range(1, count + 1):
@@ -275,9 +286,12 @@ class CrowOptionsFlowHandler(config_entries.OptionsFlow):
         if start_idx > count:
             new_data = self._config_entry.data.copy()
             new_data.update(self._temp_data)
-            self.hass.config_entries.async_update_entry(self._config_entry, data=new_data, options=self._temp_options)
-            await self.hass.config_entries.async_reload(self._config_entry.entry_id)
-            return self.async_create_entry(title="", data={})
+            # Only update entry.data here; options are saved by async_create_entry below.
+            # Passing options= here AND data={} to async_create_entry would wipe the options.
+            self.hass.config_entries.async_update_entry(self._config_entry, data=new_data)
+            # async_create_entry saves self._temp_options as the new options and
+            # automatically triggers update_listener → reload. No manual reload needed.
+            return self.async_create_entry(title="", data=self._temp_options)
 
         existing_zones = self._config_entry.options.get(CONF_ZONES, {})
         end_idx = min(start_idx + PAGE_SIZE - 1, count)

--- a/custom_components/crowipmodule/pycrowipmodule/crow_base_client.py
+++ b/custom_components/crowipmodule/pycrowipmodule/crow_base_client.py
@@ -84,6 +84,7 @@ class CrowIPModuleClient(asyncio.Protocol):
         """asyncio callback for connection lost."""
         _LOGGER.warning(f"Connection lost. Exception: {exc}")
         self._connected = False
+        self._transport = None
         if not self._shutdown:
             _LOGGER.error('The server closed the connection. Reconnecting...')
             ensure_future(self.reconnect(self._alarmPanel.connection_timeout), loop=self._eventLoop)
@@ -100,9 +101,13 @@ class CrowIPModuleClient(asyncio.Protocol):
         _LOGGER.debug('Disconnecting transport...')
         if self._transport:
             self._transport.close()
+            self._transport = None
             
     def send_data(self, data):
         """Raw data send- just make sure it's encoded properly and logged."""
+        if not self._transport:
+            _LOGGER.warning('Cannot send data: no active transport (not yet connected or reconnecting).')
+            return
         raw_bytes = (data + '\r\n').encode('ascii')
         _LOGGER.debug(f'TX RAW: {raw_bytes}')
         try:

--- a/custom_components/crowipmodule/sensor.py
+++ b/custom_components/crowipmodule/sensor.py
@@ -14,7 +14,8 @@ from .const import (
     SIGNAL_SYSTEM_UPDATE,
     SIGNAL_AREA_UPDATE,
     CONF_FW_VERSION, CONF_FW_DATE, 
-    DEFAULT_FW_VERSION, DEFAULT_FW_DATE
+    DEFAULT_FW_VERSION, DEFAULT_FW_DATE,
+    CONF_AREAS, DEFAULT_NUM_AREAS, CONF_NUM_AREAS
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -33,13 +34,19 @@ async def async_setup_entry(
     fw_date = entry.data.get(CONF_FW_DATE, DEFAULT_FW_DATE)
     
     _LOGGER.info("Setting up Crow Text Sensors")
-    
-    entities = [
-        CrowSystemSensor(controller, host, fw_version, fw_date),
-        CrowAlarmZoneSensor(controller, host, 1, "Area A Last Alarm", fw_version, fw_date),
-        CrowAlarmZoneSensor(controller, host, 2, "Area B Last Alarm", fw_version, fw_date),
-    ]
-    
+
+    configured_areas = entry.options.get(CONF_AREAS, {})
+    num_areas = len(configured_areas) or entry.data.get(CONF_NUM_AREAS, DEFAULT_NUM_AREAS)
+
+    area_labels = ["A", "B", "C", "D"]
+    entities = [CrowSystemSensor(controller, host, fw_version, fw_date)]
+    for i in range(1, num_areas + 1):
+        area_data = configured_areas.get(str(i), {})
+        area_name = area_data.get("name") or (f"Area {area_labels[i - 1]}" if i <= len(area_labels) else f"Area {i}")
+        entities.append(
+            CrowAlarmZoneSensor(controller, host, i, f"{area_name} Last Alarm", fw_version, fw_date)
+        )
+
     async_add_entities(entities, True)
 
 

--- a/custom_components/crowipmodule/switch.py
+++ b/custom_components/crowipmodule/switch.py
@@ -34,14 +34,14 @@ async def async_setup_entry(
     fw_date = entry.data.get(CONF_FW_DATE, DEFAULT_FW_DATE)
     
     entities = []
-    configured_outputs = options.get(CONF_OUTPUTS, {})
+    configured_outputs = options.get(CONF_OUTPUTS, None)
 
-    # Defaults falls leer
-    if not configured_outputs:
-        configured_outputs = {
-            "1": {"name": "Output 1"},
-            "2": {"name": "Output 2"}
-        }
+    # Only fall back to defaults when the integration has never been configured
+    # (options key absent entirely). An empty dict means the user set outputs to 0.
+    if configured_outputs is None:
+        from .const import CONF_NUM_OUTPUTS, DEFAULT_NUM_OUTPUTS
+        num = entry.data.get(CONF_NUM_OUTPUTS, DEFAULT_NUM_OUTPUTS)
+        configured_outputs = {str(i): {"name": f"Output {i}"} for i in range(1, num + 1)}
 
     for output_num_str, output_data in configured_outputs.items():
         try:


### PR DESCRIPTION

[config_flow.py] — Options flow wipes saved configuration on save
async_create_entry(data={}) in CrowOptionsFlowHandler.async_step_zones was overwriting all saved options with an empty dict. async_update_entry was also manually calling async_reload, causing a double reload on top of the update_listener. Fixed to pass data=self._temp_options to async_create_entry and removed the manual reload.

[config_flow.py] — Outputs can now be set to 0
vol.Range(min=1) changed to vol.Range(min=0) for CONF_NUM_OUTPUTS in both the initial setup and reconfigure flows. Both async_step_outputs methods now skip the form entirely when count is 0 and proceed directly to zones.

[switch.py] — 2 output entities created when outputs set to 0
The fallback "if not configured_outputs" could not distinguish between "never configured" (absent key) and "user set to 0" (empty dict). Changed to options.get(CONF_OUTPUTS, None) and only falls back to defaults when the key is entirely absent.

[alarm_control_panel.py] — Incorrect entity count and stale entity IDs after reconfigure
The fallback when configured_areas was empty always created 2 areas, ignoring CONF_NUM_AREAS. Fixed to read the configured count. The unique_id was crow_area_{n} (global) causing entity IDs to map to stale names from previous registrations. Fixed to {entry_id}crow_area{n} to scope it per config entry.

[alarm_control_panel.py] — Arming immediately resets to disarmed
After sending ARM/STAY, send_keypress(code) was called, which sends KEYS codeE, the exact same command as disarm, immediately cancelling the arm. Removed the send_keypress call from async_alarm_arm_home and async_alarm_arm_away since the Crow ARM/STAY commands are standalone.

[alarm_control_panel.py] — Code input field behaviour
code_format unconditionally returned CodeFormat.NUMBER. A previous fix returned None when a code was pre-stored but this suppressed the arm buttons in the HA card. Fixed to always return CodeFormat.NUMBER so HA renders buttons correctly, while code_arm_required returns False when a code is pre-stored, making the field optional rather than required.

[sensor.py] — Area last alarm sensors always created for 2 areas with hardcoded names
CrowAlarmZoneSensor was hardcoded to create entries for area 1 and 2 with names "Area A Last Alarm" and "Area B Last Alarm" regardless of configuration. Fixed to read CONF_AREAS from entry.options and use the user-configured area name.

[crow_base_client.py] — NoneType has no attribute write
send_data called self._transport.write() with no null guard. _transport is None before the first connection and during reconnect. Additionally disconnect() and connection_lost() did not clear _transport after closing, leaving a dead reference. Fixed with an early-return guard in send_data and self._transport = None in both disconnect() and connection_lost().

[__init__.py] — Sensor state never updates after connect or reconnect
connected_callback used hass.loop.create_task() which is not thread-safe when called from the controller's background thread. The delayed_refresh coroutine silently never ran, leaving all entities at their initial False/None state after every connect or reconnect. Fixed to use asyncio.run_coroutine_threadsafe(delayed_refresh(), hass.loop).